### PR TITLE
Modify how compiled classes are injected into the module class loader

### DIFF
--- a/nicobar-core/build.gradle
+++ b/nicobar-core/build.gradle
@@ -1,4 +1,12 @@
 project(':nicobar-core') {
+    configurations.all { 
+        resolutionStrategy.eachDependency {  DependencyResolveDetails details ->
+            if (details.requested.group == 'com.netflix.rxjava') {
+                details.useVersion '0.16.0'
+            }
+        }
+    }
+
     dependencies {
         compile 'com.google.guava:guava:15.0'
         compile 'com.google.code.gson:gson:2.2.4'

--- a/nicobar-core/src/main/java/com/netflix/nicobar/core/internal/compile/BytecodeLoader.java
+++ b/nicobar-core/src/main/java/com/netflix/nicobar/core/internal/compile/BytecodeLoader.java
@@ -39,20 +39,18 @@ public class BytecodeLoader implements ScriptArchiveCompiler {
     public Set<Class<?>> compile(ScriptArchive archive, JBossModuleClassLoader moduleClassLoader, Path targetDir)
             throws ScriptCompilationException, IOException {
         HashSet<Class<?>> addedClasses = new HashSet<Class<?>>(archive.getArchiveEntryNames().size());
-
         for (String entry : archive.getArchiveEntryNames()) {
             if (!entry.endsWith(".class")) {
                 continue;
             }
+            // Load from the underlying archive class resource
             String entryName = entry.replace(".class", "").replace("/", ".");
             try {
-                // Load from the underlying archive class resource
                 Class<?> addedClass = moduleClassLoader.loadClassLocal(entryName, true);
                 addedClasses.add(addedClass);
             } catch (Exception e) {
                 throw new ScriptCompilationException("Unable to load class: " + entryName, e);
             }
-
             moduleClassLoader.addClasses(addedClasses);
         }
 

--- a/nicobar-core/src/main/java/com/netflix/nicobar/core/module/jboss/JBossModuleClassLoader.java
+++ b/nicobar-core/src/main/java/com/netflix/nicobar/core/module/jboss/JBossModuleClassLoader.java
@@ -94,7 +94,10 @@ public class JBossModuleClassLoader extends ModuleClassLoader {
         if (local != null) {
             return local;
         }
-        return super.loadClassLocal(className, resolve);
+        local = super.loadClassLocal(className, resolve);
+        if (local != null)
+            localClassCache.put(className, local);
+        return local;
     }
 
     public ScriptArchive getScriptArchive() {

--- a/nicobar-core/src/main/java/com/netflix/nicobar/core/module/jboss/JBossModuleLoader.java
+++ b/nicobar-core/src/main/java/com/netflix/nicobar/core/module/jboss/JBossModuleLoader.java
@@ -290,4 +290,13 @@ public class JBossModuleLoader extends ModuleLoader {
         }
         return dependencyNames;
     }
+
+    /**
+     * Refresh a loaded module's resource loaders.
+     * (expose protected super class method)
+     * @param module a loaded module.
+     */
+    public void refreshModuleLoaders(Module module) {
+        super.refreshResourceLoaders(module);
+    }
 }

--- a/nicobar-groovy2/src/main/java/com/netflix/nicobar/groovy2/internal/compile/Groovy2Compiler.java
+++ b/nicobar-groovy2/src/main/java/com/netflix/nicobar/groovy2/internal/compile/Groovy2Compiler.java
@@ -20,10 +20,7 @@ package com.netflix.nicobar.groovy2.internal.compile;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
-
-import org.codehaus.groovy.tools.GroovyClass;
 
 import com.netflix.nicobar.core.archive.ScriptArchive;
 import com.netflix.nicobar.core.compile.ScriptArchiveCompiler;
@@ -46,15 +43,10 @@ public class Groovy2Compiler implements ScriptArchiveCompiler {
     @Override
     public Set<Class<?>> compile(ScriptArchive archive, JBossModuleClassLoader moduleClassLoader, Path compilationRootDir)
         throws ScriptCompilationException, IOException {
-         Set<GroovyClass> groovyClasses = new Groovy2CompilerHelper(compilationRootDir)
+         new Groovy2CompilerHelper(compilationRootDir)
             .addScriptArchive(archive)
             .withParentClassloader(moduleClassLoader)
             .compile();
-         HashSet<Class<?>> addedClasses = new HashSet<Class<?>>(archive.getArchiveEntryNames().size());
-         for (GroovyClass groovyClass : groovyClasses) {
-            Class<?> addedClass = moduleClassLoader.addClassBytes(groovyClass.getName(), groovyClass.getBytes());
-            addedClasses.add(addedClass);
-        }
-        return Collections.unmodifiableSet(addedClasses);
+        return Collections.emptySet();
     }
 }

--- a/nicobar-groovy2/src/test/java/com/netflix/nicobar/groovy2/plugin/Groovy2PluginTest.java
+++ b/nicobar-groovy2/src/test/java/com/netflix/nicobar/groovy2/plugin/Groovy2PluginTest.java
@@ -246,7 +246,7 @@ public class Groovy2PluginTest {
             .addFile(Paths.get("InternalDependencyB.groovy"))
             .addFile(Paths.get("InternalDependencyA.groovy"))
             .addFile(Paths.get("InternalDependencyD.groovy"))
-            .addFile(Paths.get("InternalDependencyC.groovy"))
+            .addFile(Paths.get("subpackage/InternalDependencyC.groovy"))
             .setModuleSpec(createGroovyModuleSpec(TestScript.INTERNAL_DEPENDENCY_A.getModuleId()).build())
             .build();
         moduleLoader.updateScriptArchives(Collections.singleton(scriptArchive));

--- a/nicobar-groovy2/src/test/resources/testmodules/internaldependencies/InternalDependencyB.groovy
+++ b/nicobar-groovy2/src/test/resources/testmodules/internaldependencies/InternalDependencyB.groovy
@@ -15,8 +15,10 @@
  *     limitations under the License.
  *
  */
-public class InternalDependencyB {
+import subpackage.InternalDependencyC
+
+public class InternalDependencyB extends InternalDependencyC {
     public String getMessage() {
-       return "I'm B. Called C and got: " + new InternalDependencyC().message;
+        return "I'm B. Called C and got: " + super.getMessage();
     }
 }

--- a/nicobar-groovy2/src/test/resources/testmodules/internaldependencies/subpackage/InternalDependencyC.groovy
+++ b/nicobar-groovy2/src/test/resources/testmodules/internaldependencies/subpackage/InternalDependencyC.groovy
@@ -1,3 +1,5 @@
+package subpackage;
+
 /*
  *
  *  Copyright 2013 Netflix, Inc.


### PR DESCRIPTION
The previous method did not work when a class being injected was a subclass of another class yet to
be injected. A variation of the problem is the case where the superclass is in a different package.

The new methodology is to ask the module's classloader to refresh its resource loader paths (which
will pick up the packages created in the compilation root directory), and then walk the compilation
tree to look for class files, and load them iteratively.

Alternative methods are possible, which will involve implementing a custom findClass() in
JBossModuleClassloader.
