### PR TITLE
Fix for a ClassPathUtils breaking bug on Windows

### DIFF
--- a/nicobar-core/src/main/java/com/netflix/nicobar/core/utils/ClassPathUtils.java
+++ b/nicobar-core/src/main/java/com/netflix/nicobar/core/utils/ClassPathUtils.java
@@ -33,6 +33,7 @@ import java.util.zip.ZipFile;
 import javax.annotation.Nullable;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.SystemUtils;
 
 /**
  * Utility methods for dealing with classes and resources in a {@link ClassLoader}
@@ -111,7 +112,13 @@ public class ClassPathUtils {
         // for Jar URL, the path is in the form of: file:/path/to/groovy/myJar.jar!/path/to/resource/myResource.txt
         int startIndex = pathString.startsWith("file:") ? 5 : 0;
         int endIndex = pathString.lastIndexOf("!");
-        Path jarPath = Paths.get(pathString.substring(startIndex, endIndex));
+        String filePath=pathString.substring(startIndex, endIndex);
+        if(SystemUtils.IS_OS_WINDOWS) {
+            // On windows, paths that start with / should be valid
+            // but the NIO API does not follow the same rules as the old IO api did and cannot parse the path from file: URLs
+            filePath=filePath.substring(1);
+        }
+        Path jarPath = Paths.get(filePath);
         return jarPath;
     }
 

--- a/nicobar-core/src/test/java/com/netflix/nicobar/core/utils/ClassPathUtilsTest.java
+++ b/nicobar-core/src/test/java/com/netflix/nicobar/core/utils/ClassPathUtilsTest.java
@@ -15,9 +15,11 @@
  */
 package com.netflix.nicobar.core.utils;
 
+import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -43,6 +45,13 @@ public class ClassPathUtilsTest {
         String classesDir = rootDir + File.separator + "classes";
         String jarPath = rootDir + File.separator + "libs" + File.separator + "nicobar-test-v1.0.jar";
         classPathStr =  classesDir + File.pathSeparator + jarPath;
+    }
+
+    @Test
+    public void testFindRootPathForResource() {
+        Path path = ClassPathUtils.findRootPathForResource("META-INF/maven/com.google.guava/guava/pom.properties", getClass().getClassLoader());
+        assertNotNull(path);
+        assertTrue(path.toFile().exists());
     }
 
     @Test


### PR DESCRIPTION
ClassPathUtils.getJarPathFromUrl breaks on windows

The nio Path API does not tolerate paths starting with "/", it really should be a JRE bug, but there is no way a fix would pass, too many code depends on the precise working on the Path API, even when it is wrong.

