### PR TITLE
Replace JCenter with Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,10 @@
 buildscript {
-    repositories { jcenter() }
+    repositories {
+        mavenCentral()
+        maven {
+            url 'https://plugins.gradle.org/m2'
+        }
+    }
     dependencies {
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.27.0'
         classpath 'com.netflix.nebula:nebula-dependency-recommender:10.0.0'

--- a/nicobar-core/nicobar-test-classes/build.gradle
+++ b/nicobar-core/nicobar-test-classes/build.gradle
@@ -1,7 +1,7 @@
 subprojects {
     apply plugin: 'java'
     repositories { 
-        jcenter()
+        mavenCentral()
     }
 
     sourceCompatibility = JavaVersion.VERSION_1_7


### PR DESCRIPTION
Hi folks,

As you might be aware, JFrog is sunsetting Bintray and JCenter: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

This is to use maven central instead of jcenter